### PR TITLE
Pin openstreetmap-carto version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -89,7 +89,9 @@ RUN fc-cache
 ###
 
 RUN \
-    git clone https://github.com/gravitystorm/openstreetmap-carto
+    git clone https://github.com/gravitystorm/openstreetmap-carto && \
+    cd openstreetmap-carto && \
+    git checkout v5.1.0
 
 ###
 # Clean


### PR DESCRIPTION
get-shapefiles.py has been [removed and apparently replaced](https://help.openstreetmap.org/questions/74861/python-script-get-shapefilespy-vanished-from-carto-tutos-for-building-a-tile-server-are-now-broken) by get-external-data-py. I tried that after installing the extra packages, but it then tried to connect to the database as the root role and I gave up, sorry!

As a workaround, pin to v5.1.0 which contains get-shapefiles.py as expected.

PS. thanks for the great repo!